### PR TITLE
Adding array property type support

### DIFF
--- a/CommandCore.Library.UnitTests/CommandParserTests.cs
+++ b/CommandCore.Library.UnitTests/CommandParserTests.cs
@@ -21,11 +21,11 @@ namespace CommandCore.Library.UnitTests
 
             Assert.NotNull(parsedVerb);
             Assert.Equal("add", parsedVerb.VerbName);
-            Assert.Equal(new Dictionary<string, string>
+            Assert.Equal(new Dictionary<string, List<string>>
             {
-                {"firstname", "tarik"},
-                {"lastname", "guney"},
-                {"zipcode", "55555"}
+                {"firstname", new List<string> {"tarik"}},
+                {"lastname", new List<string> {"guney"}},
+                {"zipcode", new List<string> {"55555"}}
             }, parsedVerb.Options);
         }
 
@@ -41,10 +41,10 @@ namespace CommandCore.Library.UnitTests
             var parsedVerb = commandParser.ParseCommand(arguments);
             Assert.NotEmpty(parsedVerb.VerbName);
             Assert.Equal("default", parsedVerb.VerbName);
-            Assert.Equal(new Dictionary<string, string>
+            Assert.Equal(new Dictionary<string, List<string>>
             {
-                {"firstname", "tarik"},
-                {"lastname", "guney"},
+                {"firstname", new List<string> {"tarik"}},
+                {"lastname", new List<string> {"guney"}},
             }, parsedVerb.Options);
         }
 
@@ -78,11 +78,11 @@ namespace CommandCore.Library.UnitTests
             };
             var parsedVerb = commandParser.ParseCommand(arguments);
             Assert.Equal("default", parsedVerb.VerbName);
-            Assert.Equal(new Dictionary<string, string>()
+            Assert.Equal(new Dictionary<string, List<string>>()
             {
-                {"t", "test"},
-                {"name", "tarik"},
-                {"g", "guney"}
+                {"t", new List<string> {"test"}},
+                {"name", new List<string> {"tarik"}},
+                {"g", new List<string> {"guney"}}
             }, parsedVerb.Options);
         }
 
@@ -100,12 +100,12 @@ namespace CommandCore.Library.UnitTests
 
             var parsedVerb = commandParser.ParseCommand(arguments);
             Assert.Equal("default", parsedVerb.VerbName);
-            Assert.Equal(new Dictionary<string, string>()
+            Assert.Equal(new Dictionary<string, List<string>>()
             {
-                {"t", "test"},
-                {"name", "tarik"},
-                {"g", "guney"},
-                {"hello", "world"}
+                {"t", new List<string> {"test"}},
+                {"name", new List<string> {"tarik"}},
+                {"g", new List<string> {"guney"}},
+                {"hello", new List<string> {"world"}}
             }, parsedVerb.Options);
         }
     }

--- a/CommandCore.Library.UnitTests/CommandVerbRunnerTests.cs
+++ b/CommandCore.Library.UnitTests/CommandVerbRunnerTests.cs
@@ -58,9 +58,9 @@ namespace CommandCore.Library.UnitTests
             var args = new[] {"--name", "tarik"};
             var testVerbInfo = new ParsedVerb()
             {
-                VerbName = "default", Options = new Dictionary<string, string>()
+                VerbName = "default", Options = new Dictionary<string, List<string>>()
                 {
-                    {"name", "tarik"}
+                    {"name", new List<string> {"tarik"}}
                 }
             };
             _commandParseMock.Setup(a => a.ParseCommand(It.IsAny<string[]>()))

--- a/CommandCore.Library.UnitTests/OptionsParserTest.cs
+++ b/CommandCore.Library.UnitTests/OptionsParserTest.cs
@@ -20,7 +20,9 @@ namespace CommandCore.Library.UnitTests
                     {"Age", new List<string> {"33"}},
                     {"ismale", new List<string> {"true"}},
                     {"countries", new List<string> {"usa", "germany", "turkey"}},
-                    {"scores", new List<string> {"2", "3", "4"}}
+                    {"scores", new List<string> {"2", "3", "4"}},
+                    {"skills", new List<string> {"programming"}},
+                    {"ids", new List<string>()}
                 }
             });
             Assert.NotNull(optionsObject);
@@ -29,6 +31,9 @@ namespace CommandCore.Library.UnitTests
             Assert.True(optionsObject.Male);
             Assert.Equal(new List<string> {"usa", "germany", "turkey"}, optionsObject.Countries);
             Assert.Equal(new List<int> {2, 3, 4}, optionsObject.Scores);
+            IReadOnlyList<string> expectedSkills = new List<string>() {"programming"};
+            Assert.Equal(expectedSkills, optionsObject.Skills);
+            Assert.Null(optionsObject.Ids);
         }
 
         [Fact]

--- a/CommandCore.Library.UnitTests/OptionsParserTest.cs
+++ b/CommandCore.Library.UnitTests/OptionsParserTest.cs
@@ -19,14 +19,16 @@ namespace CommandCore.Library.UnitTests
                     {"Name", new List<string> {"tarik"}},
                     {"Age", new List<string> {"33"}},
                     {"ismale", new List<string> {"true"}},
-                    {"countries", new List<string> {"usa", "germany", "turkey"}}
+                    {"countries", new List<string> {"usa", "germany", "turkey"}},
+                    {"scores", new List<string> {"2", "3", "4"}}
                 }
             });
             Assert.NotNull(optionsObject);
             Assert.Equal("tarik", optionsObject.Name);
             Assert.Equal(33, optionsObject.Age);
             Assert.True(optionsObject.Male);
-            Assert.Equal(optionsObject.Countries, new List<string> {"usa", "germany", "turkey"});
+            Assert.Equal(new List<string> {"usa", "germany", "turkey"}, optionsObject.Countries);
+            Assert.Equal(new List<int> {2, 3, 4}, optionsObject.Scores);
         }
 
         [Fact]

--- a/CommandCore.Library.UnitTests/OptionsParserTest.cs
+++ b/CommandCore.Library.UnitTests/OptionsParserTest.cs
@@ -14,11 +14,11 @@ namespace CommandCore.Library.UnitTests
             var optionsObject = (TestOptions) parser.CreatePopulatedOptionsObject(typeof(TestVerb), new ParsedVerb()
             {
                 VerbName = "TestVerb",
-                Options = new Dictionary<string, string>()
+                Options = new Dictionary<string, List<string>>()
                 {
-                    {"Name", "tarik"},
-                    {"Age", "33"},
-                    {"ismale", "true"}
+                    {"Name", new List<string> {"tarik"}},
+                    {"Age", new List<string> {"33"}},
+                    {"ismale", new List<string> {"true"}}
                 }
             });
             Assert.NotNull(optionsObject);
@@ -34,11 +34,11 @@ namespace CommandCore.Library.UnitTests
             var optionsObject = (TestOptions) parser.CreatePopulatedOptionsObject(typeof(TestVerb), new ParsedVerb()
             {
                 VerbName = "TestVerb",
-                Options = new Dictionary<string, string>()
+                Options = new Dictionary<string, List<string>>()
                 {
-                    {"Name", "tarik"},
-                    {"age", "33"},
-                    {"ismale", "true"}
+                    {"Name", new List<string> {"tarik"}},
+                    {"age", new List<string> {"33"}},
+                    {"ismale", new List<string> {"true"}}
                 }
             });
             Assert.NotNull(optionsObject);
@@ -54,7 +54,7 @@ namespace CommandCore.Library.UnitTests
             var optionsObject = (TestOptions) parser.CreatePopulatedOptionsObject(typeof(TestVerb), new ParsedVerb()
             {
                 VerbName = "TestVerb",
-                Options = new Dictionary<string, string>()
+                Options = new Dictionary<string, List<string>>()
             });
             Assert.NotNull(optionsObject);
             Assert.Null(optionsObject.Name);
@@ -69,11 +69,11 @@ namespace CommandCore.Library.UnitTests
             var optionsObject = (TestOptions) parser.CreatePopulatedOptionsObject(typeof(TestVerb), new ParsedVerb()
             {
                 VerbName = "TestVerb",
-                Options = new Dictionary<string, string>()
+                Options = new Dictionary<string, List<string>>()
                 {
-                    {"n", "tarik"},
-                    {"a", "33"},
-                    {"m", "true"}
+                    {"n", new List<string> {"tarik"}},
+                    {"a", new List<string> {"33"}},
+                    {"m", new List<string> {"true"}}
                 }
             });
             Assert.NotNull(optionsObject);
@@ -90,9 +90,9 @@ namespace CommandCore.Library.UnitTests
                 new ParsedVerb()
                 {
                     VerbName = "TestVerb",
-                    Options = new Dictionary<string, string>
+                    Options = new Dictionary<string, List<string>>
                     {
-                        {"Money", "12.55"}
+                        {"Money", new List<string> {"12.55"}}
                     }
                 });
 
@@ -107,11 +107,11 @@ namespace CommandCore.Library.UnitTests
             var optionsObject = (TestOptions) parser.CreatePopulatedOptionsObject(typeof(TestVerb), new ParsedVerb()
             {
                 VerbName = "TestVerb",
-                Options = new Dictionary<string, string>()
+                Options = new Dictionary<string, List<string>>()
                 {
-                    {"fn", "tarik"},
-                    {"a", "33"},
-                    {"im", "true"}
+                    {"fn", new List<string> {"tarik"}},
+                    {"a", new List<string> {"33"}},
+                    {"im", new List<string> {"true"}}
                 }
             });
             Assert.NotNull(optionsObject);

--- a/CommandCore.Library.UnitTests/OptionsParserTest.cs
+++ b/CommandCore.Library.UnitTests/OptionsParserTest.cs
@@ -18,13 +18,15 @@ namespace CommandCore.Library.UnitTests
                 {
                     {"Name", new List<string> {"tarik"}},
                     {"Age", new List<string> {"33"}},
-                    {"ismale", new List<string> {"true"}}
+                    {"ismale", new List<string> {"true"}},
+                    {"countries", new List<string> {"usa", "germany", "turkey"}}
                 }
             });
             Assert.NotNull(optionsObject);
             Assert.Equal("tarik", optionsObject.Name);
             Assert.Equal(33, optionsObject.Age);
             Assert.True(optionsObject.Male);
+            Assert.Equal(optionsObject.Countries, new List<string> {"usa", "germany", "turkey"});
         }
 
         [Fact]

--- a/CommandCore.Library.UnitTests/TestTypes/TestOptions.cs
+++ b/CommandCore.Library.UnitTests/TestTypes/TestOptions.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using System.Collections.Generic;
 using CommandCore.Library.Attributes;
 using CommandCore.Library.PublicBase;
@@ -24,6 +25,12 @@ namespace CommandCore.Library.UnitTests.TestTypes
 
         [OptionName("scores")]
         public List<int> Scores { get; set; }
+        
+        [OptionName("skills")]
+        public IReadOnlyList<string> Skills { get; set; }
+        
+        [OptionName("ids")]
+        public IList<double> Ids { get; set; }
     }
 
 }

--- a/CommandCore.Library.UnitTests/TestTypes/TestOptions.cs
+++ b/CommandCore.Library.UnitTests/TestTypes/TestOptions.cs
@@ -17,6 +17,9 @@ namespace CommandCore.Library.UnitTests.TestTypes
         public bool Male { get; set; }
 
         public decimal Money { get; set; }
+        
+        [OptionName("countries")]
+        public string[] Countries { get; set; }
     }
 
 }

--- a/CommandCore.Library.UnitTests/TestTypes/TestOptions.cs
+++ b/CommandCore.Library.UnitTests/TestTypes/TestOptions.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using CommandCore.Library.Attributes;
 using CommandCore.Library.PublicBase;
 
@@ -20,6 +21,9 @@ namespace CommandCore.Library.UnitTests.TestTypes
         
         [OptionName("countries")]
         public string[] Countries { get; set; }
+
+        [OptionName("scores")]
+        public List<int> Scores { get; set; }
     }
 
 }

--- a/CommandCore.Library/CommandParser.cs
+++ b/CommandCore.Library/CommandParser.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Linq;
 using CommandCore.Library.Interfaces;
 
 namespace CommandCore.Library
@@ -11,7 +12,7 @@ namespace CommandCore.Library
             {
                 return new ParsedVerb() {VerbName = "default"};
             }
-            
+
             var argumentsClone = (string[]) arguments.Clone();
             var parsedVerb = new ParsedVerb();
 
@@ -33,25 +34,18 @@ namespace CommandCore.Library
                 return parsedVerb;
             }
 
-            var options = new Dictionary<string, string>();
+            var options = new Dictionary<string, List<string>>();
 
             for (int i = startingPoint; i < arguments.Length; i++)
             {
-                if (arguments[i].StartsWith("-"))
+                var arg = arguments[i];
+                if (arg.StartsWith("-") || arg.StartsWith("--"))
                 {
-                    // Checking if the option is with a value like --name "Tarik" or -n "Tarik"
-                    if (arguments.Length - 1 >= i + 1 && !arguments[i + 1].StartsWith("-"))
-                    {
-                        options[arguments[i].TrimStart('-')] = arguments[i + 1];
-                        // We already captured the value which is the next item in the array, so we can skip it.
-                        i++;
-                    }
-                    // Checking if the option is a flag like --visible or -v, which is automatically inferred as --visible
-                    // true. If the --argument is the last item or a value does not follow it, it means it is a flag.
-                    else if (arguments.Length - 1 == i || arguments[i + 1].StartsWith("-"))
-                    {
-                        options[arguments[i].TrimStart('-')] = "true";
-                    }
+                    options.Add(arg.Trim('-'), new List<string>());
+                }
+                else
+                {
+                    options[options.Keys.Last()].Add(arg);
                 }
             }
 

--- a/CommandCore.Library/Models/ParsedVerb.cs
+++ b/CommandCore.Library/Models/ParsedVerb.cs
@@ -6,5 +6,5 @@ public class ParsedVerb
 
     // ToDo: Ideally the value should be anything. I don't know how I should design this right now. 
     // The reason is simple: Some arguments are flag attributes.
-    public IReadOnlyDictionary<string, string>? Options { get; set; }
+    public IReadOnlyDictionary<string, List<string>>? Options { get; set; }
 }

--- a/CommandCore.Library/OptionsParser.cs
+++ b/CommandCore.Library/OptionsParser.cs
@@ -46,6 +46,9 @@ namespace CommandCore.Library
                 {
                     var argumentValues = parsedVerb.Options[parameterName];
 
+                    // I am aware of the relative complexity of the following big ass if conditions. I will simplify
+                    // it one, hopefully. But the idea is simple: A property type may be an array, a collection, or a scalar type.
+                    // And, we are paring them accordingly.
                     var propType = propertyInfo.PropertyType;
                     if (propType.IsArray)
                     {

--- a/CommandCore.Library/OptionsParser.cs
+++ b/CommandCore.Library/OptionsParser.cs
@@ -49,9 +49,12 @@ namespace CommandCore.Library
                     if (propType.IsArray)
                     {
                         var elType = propType.GetElementType();
-                        var converter = TypeDescriptor.GetConverter(elType);
-                        var value = argumentValue.Select(a => converter.ConvertFrom(a)).ToArray();
-                        propertyInfo.SetValue(options, value);
+                        var array = Array.CreateInstance(elType, argumentValue.Count);
+                        for (var i = 0; i < argumentValue.Count; i++)
+                        {
+                            array.SetValue(Convert.ChangeType(argumentValue[i], elType), i);
+                        }
+                        propertyInfo.SetValue(options, array);
                     }
                     else if (propType.IsSubclassOf(typeof(IEnumerable<>)))
                     {
@@ -67,7 +70,7 @@ namespace CommandCore.Library
                     else
                     {
                         var converter = TypeDescriptor.GetConverter(propType);
-                        propertyInfo.SetValue(options, converter.ConvertFrom(argumentValue));
+                        propertyInfo.SetValue(options, converter.ConvertFrom(argumentValue[0]));
                     }
                 }
             }


### PR DESCRIPTION
The idea is simple:

`test add -n hello tarik guney` should be parsed to a property `public string[] Hello {get;set;}`